### PR TITLE
Complete the Symfony adapters for interactive and decorated

### DIFF
--- a/src/Adapter/ArgsInput.php
+++ b/src/Adapter/ArgsInput.php
@@ -36,6 +36,11 @@ class ArgsInput implements InputInterface
     private $args;
 
     /**
+     * @var bool
+     */
+    private $interactive = true;
+
+    /**
      * Creates the adapter.
      *
      * @param RawArgs $rawArgs The unparsed console arguments.
@@ -223,7 +228,7 @@ class ArgsInput implements InputInterface
      */
     public function isInteractive()
     {
-        return true;
+        return $this->interactive;
     }
 
     /**
@@ -231,5 +236,6 @@ class ArgsInput implements InputInterface
      */
     public function setInteractive($interactive)
     {
+        $this->interactive = $interactive;
     }
 }

--- a/src/Adapter/IOOutput.php
+++ b/src/Adapter/IOOutput.php
@@ -14,6 +14,7 @@ namespace Webmozart\Console\Adapter;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webmozart\Console\Api\IO\IO;
+use Webmozart\Console\Formatter\AnsiFormatter;
 
 /**
  * Adapts an {@link IO} instance to Symfony's {@link OutputInterface} API.
@@ -30,6 +31,11 @@ class IOOutput implements OutputInterface
     private $io;
 
     /**
+     * @var bool
+     */
+    private $decorated;
+
+    /**
      * Creates a new composite output.
      *
      * @param IO $io The I/O.
@@ -37,6 +43,7 @@ class IOOutput implements OutputInterface
     public function __construct(IO $io)
     {
         $this->io = $io;
+        $this->decorated = $this->io->getFormatter() instanceof AnsiFormatter;
     }
 
     /**
@@ -162,6 +169,7 @@ class IOOutput implements OutputInterface
      */
     public function setDecorated($decorated)
     {
+        $this->decorated = $decorated;
     }
 
     /**
@@ -169,7 +177,7 @@ class IOOutput implements OutputInterface
      */
     public function isDecorated()
     {
-        return false;
+        return $this->decorated;
     }
 
     /**

--- a/tests/Adapter/ArgsInputTest.php
+++ b/tests/Adapter/ArgsInputTest.php
@@ -231,4 +231,15 @@ class ArgsInputTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($inputArgs->hasOption('option3'));
         $this->assertFalse($inputNoArgs->hasOption('option1'));
     }
+
+    public function testSetInteractive()
+    {
+        $inputArgs = new ArgsInput($this->rawArgs, $this->args);
+
+        $this->assertTrue($inputArgs->isInteractive());
+
+        $inputArgs->setInteractive(false);
+
+        $this->assertFalse($inputArgs->isInteractive());
+    }
 }

--- a/tests/Adapter/IOOutputTest.php
+++ b/tests/Adapter/IOOutputTest.php
@@ -19,6 +19,7 @@ use Webmozart\Console\Adapter\IOOutput;
 use Webmozart\Console\Api\IO\Input;
 use Webmozart\Console\Api\IO\IO;
 use Webmozart\Console\Api\IO\Output;
+use Webmozart\Console\Formatter\AnsiFormatter;
 use Webmozart\Console\IO\InputStream\StringInputStream;
 use Webmozart\Console\IO\OutputStream\BufferedOutputStream;
 
@@ -282,6 +283,34 @@ class IOOutputTest extends PHPUnit_Framework_TestCase
         $this->io->setQuiet(true);
 
         $this->assertSame(OutputInterface::VERBOSITY_QUIET, $this->output->getVerbosity());
+    }
+
+    public function testIsDecorated()
+    {
+        $input = new Input(new StringInputStream());
+        $output = new Output(new BufferedOutputStream(), new AnsiFormatter());
+        $nonDecoratedOutput = new Output(new BufferedOutputStream());
+        $errorOutput = new Output(new BufferedOutputStream());
+
+        // Decorated
+        $this->io = new IO($input, $output, $errorOutput);
+        $this->output = new IOOutput($this->io);
+
+        $this->assertTrue($this->output->isDecorated());
+
+        $this->output->setDecorated(false);
+
+        $this->assertFalse($this->output->isDecorated());
+
+        // Non decorated
+        $this->io = new IO($input, $nonDecoratedOutput, $errorOutput);
+        $this->output = new IOOutput($this->io);
+
+        $this->assertFalse($this->output->isDecorated());
+
+        $this->output->setDecorated(true);
+
+        $this->assertTrue($this->output->isDecorated());
     }
 
     public function testGetFormatter()


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Bug Fix?     |yes|
|New Feature? |no |
|BC Breaks?   |no |
|Deprecations?|no |
|Tests Pass?  |yes|
|Fixed Tickets|   |
|License      |MIT|
                   

This completes the adapters for the Symfony Console component.
Both interactive and decorated now work as expected.

@webmozart please review this as soon as possible as the Symfony QuestionHelper
doesn't work properly without these changes.