### PR TITLE
Replace symfony license headers with webmozart license headers

### DIFF
--- a/src/IO/ConsoleIO.php
+++ b/src/IO/ConsoleIO.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the Symfony package.
+ * This file is part of the webmozart/console package.
  *
- * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Bernhard Schussek <bschussek@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/UI/Component/Grid.php
+++ b/src/UI/Component/Grid.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the Symfony package.
+ * This file is part of the webmozart/console package.
  *
- * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Bernhard Schussek <bschussek@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
There were still a couple of files that had the old Symfony license
header. This files are now consistent with the rest of the package.